### PR TITLE
Only modify urls if running as DEBUG and not during unit tests.

### DIFF
--- a/aldryn_django_debug_toolbar/urls.py
+++ b/aldryn_django_debug_toolbar/urls.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
+from django.conf import settings
 from django.conf.urls import url, include
 
+import sys
 import debug_toolbar
 
-urlpatterns = [url(r'^__debug__/', include(debug_toolbar.urls))]
+if settings.DEBUG and 'test' not in sys.argv:
+    urlpatterns = [url(r'^__debug__/', include(debug_toolbar.urls))]


### PR DESCRIPTION
Only modify urls DEBUG is True:
Should be obvious why this is a good idea.

Disable during unit testing:
Django debug toolbar and view based tests don't always work well together don't add debug toolbar urls when running unit tests.